### PR TITLE
Summarise filtering options

### DIFF
--- a/dbSNP/dbsnp_app/templates/dbsnp_app/home.html
+++ b/dbSNP/dbsnp_app/templates/dbsnp_app/home.html
@@ -2,7 +2,7 @@
 {% extends 'dbsnp_app/template.html' %} <!-- template inheritance -->
 
 {% block title %}
-Homepage
+Home
 {% endblock %}
 
 {% if messages %}
@@ -14,44 +14,95 @@ Homepage
 {% endif %} 
 
 {% block content %}
-<h1>Database of single nucleotide variants</h1>
+<h1>Database of single nucleotide variants (GRCh38)</h1>
 
 <!-- <a href="/submit/"><button type="button" class = "bt btn-primary">Submit new</button></a></br></br> -->
-{% endblock %}
 
-{% block table %}
-<table style="width:98%" class="table table-striped table-sm table-responsive">
-<thead class="thead-inverse">
-	<tr> <!--define header-->
-		<th >Variant ID</th>
-		<th >Reference genome</th>
-		<th >Chromosome</th>
-		<th >Start coordinate</th>
-		<th >End coordinate</th>
-		<th >Reference allele</th>
-		<th >Alternative allele</th>
-		<th >Minor allele frequency</th>
-		<th >Variant class</th>
-		<th >External links</th>
-	</tr>
-</thead>
-<tbody>
-	{% for variant in variants %} <!-- create a new row for each variant submitted  -->
-	<tr> 	<!--'variants' is the key in the content dictionary provided in the views.py -->
-		<td><a href="https://www.ncbi.nlm.nih.gov/snp/{{variant.dbSNP_ID}}">{{ variant.dbSNP_ID }}</a></td>
-		<td>{{ variant.refGen }}</td>
-		<td>{{ variant.chr }}</td>
-		<td>{{ variant.start }}</td>
-		<td>{{ variant.end }}</td>
-		<td>{{ variant.ref }}</td>
-		<td>{{ variant.alt }}</td>
-		<td>{{ variant.MAF }}</td>
-		<td>{{ variant.var_class }}</td>
-		<td><a href="https://genome-euro.ucsc.edu/cgi-bin/hgTracks?db=hg38&lastVirtModeType=default&lastVirtModeExtraState=&virtModeType=default&virtMode=0&nonVirtPosition=&position=chr{{variant.chr}}%3A{{variant.start}}-{{variant.end}}">UCSC</a> , <a href="https://gnomad.broadinstitute.org/variant/{{ variant.chr }}-{{ variant.start }}-{{variant.ref}}-{{variant.alt}}?dataset=gnomad_r3">gnomAD</a></td>
-	</tr>
-	{% endfor %}  <!-- always have to close for loops in HTML -->
-</tbody>
-</table>
+<label for="chromosomes">Filter by exact match:</label>
+<form action="{% url 'results' %}" method="get">
+	<select name="chrom" id="chrom">
+		<option selected="selected" disabled>Chromosome</option>
+			<option value="1">1</option>
+			<option value="2">2</option>
+			<option value="3">3</option>
+			<option value="4">4</option>
+			<option value="5">5</option>
+			<option value="6">6</option>
+			<option value="7">7</option>
+			<option value="8">8</option>
+			<option value="9">9</option>
+			<option value="10">10</option>
+			<option value="11">11</option>
+			<option value="12">12</option>
+			<option value="13">13</option>
+			<option value="14">14</option>
+			<option value="15">15</option>
+			<option value="16">16</option>
+			<option value="17">17</option>
+			<option value="18">18</option>
+			<option value="19">19</option>
+			<option value="20">20</option>
+			<option value="21">21</option>
+			<option value="22">22</option>
+			<option value="X">X</option>
+			<option value="Y">Y</option>
+	</select>
+	<!-- <input name="chr" type="text" placeholder="chr"> -->
+	<input name="start" type="text" placeholder="Start">
+	<input name="end" type="text" placeholder="End">
+	<select name="vartype" id="vartype">
+		<option selected="selected" disabled>Variant type</option>
+			<option value="SNP">SNP</option>
+			<option value="deletion">deletion</option>
+			<option value="insertion">insertion</option>
+			<option value="indel">indel</option>
+	</select>
+	<select name="conseq" id="conseq">
+		<option selected="selected" disabled>Consequence</option>
+			<option value="synonymous_variant">synonymous_variant</option>
+			<option value="missense_variant">missense_variant</option>
+			<option value="protein_altering_variant">protein_altering_variant</option>
+			<option value="exon_variant">exon_variant</option>
+			<option value="intron_variant">intron_variant</option>
+			<option value="frameshift_variant">frameshift_variant</option>
+			<option value="splice_region_variant">splice_region_variant</option>
+			<option value="splice_donor_variant">splice_donor_variant</option>
+			<option value="splice_acceptor_variant">splice_acceptor_variant</option>
+			<option value="start_lost">start_lost</option>
+			<option value="stop_gained">stop_gained</option>
+			<option value="5_prime_UTR_variant">5_prime_UTR_variant</option>
+			<option value="3_prime_UTR_variant">3_prime_UTR_variant</option>
+			<option value="upstream_gene_variant">upstream_gene_variant</option>
+			<option value="downstream_gene_variant">downstream_gene_variant</option>
+			<option value="*">*</option>
+	</select>
+	<select name="clinsig" id="clinsig">
+		<option selected="selected" disabled>Clinical significance:</option>
+			<option value="pathogenic">pathogenic</option>
+			<option value="likely pathogenic">likely pathogenic</option>
+			<option value="uncertain significance">uncertain significance</option>
+			<option value="likely benign">likely benign</option>
+			<option value="benign">benign</option>
+			<option value="risk factor">risk factor</option>
+			<option value="not provided">not provided</option>
+	</select>
+	<button type="submit" class="save btn btn-default" name="exact" value="exact">Submit filters</button>
+</form>
+
+<label for="chromosomes">Filter by range:</label>
+<form action="{% url 'results' %}" method="get">
+	<input name="range_chr" type="text" placeholder="Chromosome">
+	<input name="range_start" type="int" placeholder="Range start">
+	<input name="range_end" type="int" placeholder="Range end">
+	<select name="MAF" id="MAF">
+		<option selected="selected" disabled>MAF ranges</option>
+			<option value="0.00-0.25">0.00-0.25</option>
+			<option value="0.25-0.75">0.25-0.75</option>
+			<option value="0.75-1.00">0.75-1.00</option>
+	</select>
+	<button type="submit" class="save btn btn-default" name="range" value="range">Submit range</button>
+</form>
+<br>
 {% endblock %}
 
 {% block home-button %}

--- a/dbSNP/dbsnp_app/templates/dbsnp_app/results.html
+++ b/dbSNP/dbsnp_app/templates/dbsnp_app/results.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+{% extends 'dbsnp_app/template.html' %} <!-- template inheritance -->
+
+{% block title %}
+Home
+{% endblock %}
+
+{% if messages %}
+    {% for message in messages %}
+        <div class="alert {{message.tags}}">
+            <strong>{{ message }}</strong> 
+        </div>
+    {% endfor %}
+{% endif %} 
+
+{% block content %}
+<h1>Filtering results</h1>
+
+<!-- <a href="/submit/"><button type="button" class = "bt btn-primary">Submit new</button></a></br></br> -->
+
+<br>
+<form action="{% url 'results' %}" method="get">
+<input name="limit" type="text" placeholder="Limit results">
+</form>
+<br>
+
+{% endblock %}
+
+<!-- <a href="{% url 'home' %}"><button type="button" name = "home" class = "bt btn-primary">Back to database selection</button></a> -->

--- a/dbSNP/dbsnp_app/templates/dbsnp_app/results.html
+++ b/dbSNP/dbsnp_app/templates/dbsnp_app/results.html
@@ -2,7 +2,7 @@
 {% extends 'dbsnp_app/template.html' %} <!-- template inheritance -->
 
 {% block title %}
-Home
+Filtering
 {% endblock %}
 
 {% if messages %}
@@ -18,8 +18,6 @@ Home
 <h4>for the following query:</h4>
 <p>{{ filters }}</p>
 
-<!-- <a href="/submit/"><button type="button" class = "bt btn-primary">Submit new</button></a></br></br> -->
-
 <br>
 <form action="{% url 'results' %}" method="get">
 <input name="limit" type="text" placeholder="Limit results">
@@ -27,5 +25,3 @@ Home
 <br>
 
 {% endblock %}
-
-<!-- <a href="{% url 'home' %}"><button type="button" name = "home" class = "bt btn-primary">Back to database selection</button></a> -->

--- a/dbSNP/dbsnp_app/templates/dbsnp_app/results.html
+++ b/dbSNP/dbsnp_app/templates/dbsnp_app/results.html
@@ -15,6 +15,8 @@ Home
 
 {% block content %}
 <h1>Filtering results</h1>
+<h4>for the following query:</h4>
+<p>{{ filters }}</p>
 
 <!-- <a href="/submit/"><button type="button" class = "bt btn-primary">Submit new</button></a></br></br> -->
 

--- a/dbSNP/dbsnp_app/templates/dbsnp_app/template.html
+++ b/dbSNP/dbsnp_app/templates/dbsnp_app/template.html
@@ -20,7 +20,7 @@
 	<body>
 		<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
 			<div class="container">
-				<a class="navbar-brand" href="{% url 'home' %}">Homepage</a>
+				<a class="navbar-brand" href="{% url 'home' %}">Variant database</a>
 			</div>
 		</nav>
 		
@@ -35,23 +35,52 @@
 		{% endblock %}
 
 		{% block table %}
-		<table style="width:80%" class="table table-striped table-sm table-responsive">
-			<thead class="thead-inverse"> <!--define header-->
-				{% for h in header_list %} 
-				<th class="th-lg"> {{h}} </th>
-				{% endfor %}
+			<table style="width:98%" class="table table-striped table-sm table-responsive">
+			<thead class="thead-inverse">
+				<tr> <!--define header-->
+					<!-- <th >Reference genome</th> -->
+					<th >Chromosome</th>
+					<th >Start</th>
+					<th >End</th>
+					<th >Reference</th>
+					<th >Alternative</th>
+					<th >Variant type</th>
+					<th >Consequence</th>
+					<th >Synonyms</th>
+					<th >MAF</th>
+					<th >Clinical significance</th>
+					<th >Evidence sources</th>
+					<th >Variant ID</th>
+					<th >External links</th>
+				</tr>
 			</thead>
 			<tbody>
-				{% for n in content_list %} 
-				<td class="align-middle"> {{n}} </td>
-				{% endfor %}
+				{% for variant in variants %} <!-- create a new row for each variant submitted  -->
+				<tr> 	<!--'variants' is the key in the content dictionary provided in the views.py -->
+					<!-- <td>{{ variant.refGen }}</td> -->
+					<td>{{ variant.chr }}</td>
+					<td>{{ variant.start }}</td>
+					<td>{{ variant.end }}</td>
+					<td>{{ variant.ref }}</td>
+					<td>{{ variant.alt }}</td>
+					<td>{{ variant.var_class }}</td>
+					<td>{{ variant.consequence }}</td>
+					<td>{% for syn in variant.synonyms %}
+						{{syn}}<br>{% endfor %}</td>
+					<td>{{ variant.MAF }}</td>
+					<td>{{ variant.clin_sig }}</td>
+					<td>{{ variant.evidence }}</td>
+					<td><a href="https://www.ncbi.nlm.nih.gov/snp/{{variant.dbSNP_ID}}">{{ variant.dbSNP_ID }}</a></td>
+					<td><a href="https://genome-euro.ucsc.edu/cgi-bin/hgTracks?db=hg38&lastVirtModeType=default&lastVirtModeExtraState=&virtModeType=default&virtMode=0&nonVirtPosition=&position=chr{{variant.chr}}%3A{{variant.start}}-{{variant.end}}">UCSC</a> , <a href="https://gnomad.broadinstitute.org/variant/{{ variant.chr }}-{{ variant.start }}-{{variant.ref}}-{{variant.alt}}?dataset=gnomad_r3">gnomAD</a></td>
+				</tr>
+				{% endfor %}  <!-- always have to close for loops in HTML -->
 			</tbody>
-		</table>
+			</table>
 		{% endblock %}
 
 
 		{% block home-button %}
-		<a href="{% url 'home' %}"><button type="button" name = "home" class = "bt btn-primary">Back to database selection</button></a>
+			<a href="{% url 'home' %}"><button type="button" name = "home" class = "bt btn-primary">Back to overview</button></a>
 		{% endblock %}
 		</div>
 

--- a/dbSNP/dbsnp_app/urls.py
+++ b/dbSNP/dbsnp_app/urls.py
@@ -2,8 +2,9 @@ from django.urls import path, include
 from . import views
 
 urlpatterns = [
-	path("", views.index, name="index"),
+	path("", views.home, name="home"),
 	path("home/", views.home, name="home"),
+	path("results/", views.results, name="results")
 
 ]
 

--- a/dbSNP/dbsnp_app/urls.py
+++ b/dbSNP/dbsnp_app/urls.py
@@ -4,7 +4,7 @@ from . import views
 urlpatterns = [
 	path("", views.home, name="home"),
 	path("home/", views.home, name="home"),
-	path("results/", views.results, name="results")
+	path("results/", views.results, name="results"),
 
 ]
 

--- a/dbSNP/dbsnp_app/views.py
+++ b/dbSNP/dbsnp_app/views.py
@@ -54,6 +54,52 @@ def home(request):
     content_dict = {'variants': data_list}
     return render(request, "dbsnp_app/home.html", content_dict)
 
+
+def results(request):
+    search_dict = {}
+
+    if request.GET.get('exact'):
+        try:
+            if request.GET['chrom'] is not None:    
+                search_dict.update({"mappings.seq_region_name": request.GET['chrom']})
+        except: pass
+        if request.GET['start'] is not None and request.GET['start'] != "":
+            search_dict.update({"mappings.start": int(request.GET['start'])})
+        if request.GET['end'] is not None and request.GET['end'] != "":
+            search_dict.update({"mappings.end": int(request.GET['end'])})
+        try:
+            if request.GET['vartype'] is not None:
+                search_dict.update({"var_class": request.GET['vartype']})
+        except: pass
+        try:
+            if request.GET['conseq'] is not None:
+                search_dict.update({"most_severe_consequence": request.GET['conseq']})
+        except: pass
+        try:
+            if request.GET['clinsig'] is not None:
+                search_dict.update({"clinical_significance": request.GET['clinsig']})
+        except: pass
+
+    elif request.GET.get('range'):
+        try:
+            if request.GET['range_chr'] is not None:
+                search_dict.update({"mappings.0.seq_region_name": request.GET['range_chr']})
+        except: pass
+        if request.GET['range_start'] is not None and request.GET['range_start'] != "" and \
+            request.GET['range_end'] is not None and request.GET['range_end'] != "":
+            search_dict.update({"mappings.start": { "$gte": int(request.GET['range_start'])},
+            "mappings.end": { "$lte": int(request.GET['range_end'])}})
+
+    try:
+        if request.GET['limit'] is not None and request.GET['limit'] != "":
+            limit = int(request.GET['limit'])
+    except:
+        limit = 20
+
+    data_list = query_db(search_dict, limit)
+    content_dict = {'variants': data_list}
+    return render(request, "dbsnp_app/results.html", content_dict)
+
 # Available fields based on the first 200 records
 # {'_id': <class 'bson.objectid.ObjectId'>,
 # 'MAF': <class 'str'>, 'ambiguity': <class 'str'>, 'ancestral_allele': <class 'str'>,

--- a/dbSNP/dbsnp_app/views.py
+++ b/dbSNP/dbsnp_app/views.py
@@ -57,38 +57,55 @@ def home(request):
 
 def results(request):
     search_dict = {}
+    filter_str = ""
 
     if request.GET.get('exact'):
         try:
-            if request.GET['chrom'] is not None:    
+            if request.GET['chrom'] is not None:
                 search_dict.update({"mappings.seq_region_name": request.GET['chrom']})
+                filter_str += "chromosome: " + request.GET['chrom'] + ", "
         except: pass
         if request.GET['start'] is not None and request.GET['start'] != "":
             search_dict.update({"mappings.start": int(request.GET['start'])})
+            filter_str += "start position: " + request.GET['start'] + ", "
         if request.GET['end'] is not None and request.GET['end'] != "":
             search_dict.update({"mappings.end": int(request.GET['end'])})
+            filter_str += "end position: " + request.GET['end'] + ", "
         try:
             if request.GET['vartype'] is not None:
                 search_dict.update({"var_class": request.GET['vartype']})
+                filter_str += "variant type: " + request.GET['vartype'] + ", "
         except: pass
         try:
             if request.GET['conseq'] is not None:
                 search_dict.update({"most_severe_consequence": request.GET['conseq']})
+                filter_str += "consequence: " + request.GET['conseq'] + ", "
         except: pass
         try:
             if request.GET['clinsig'] is not None:
                 search_dict.update({"clinical_significance": request.GET['clinsig']})
+                filter_str += "clinical significance: " + request.GET['clinsig'] + ", "
         except: pass
 
     elif request.GET.get('range'):
         try:
             if request.GET['range_chr'] is not None:
                 search_dict.update({"mappings.0.seq_region_name": request.GET['range_chr']})
+                filter_str += "chromosome: " + request.GET['range_chr'] + ", "
         except: pass
         if request.GET['range_start'] is not None and request.GET['range_start'] != "" and \
             request.GET['range_end'] is not None and request.GET['range_end'] != "":
             search_dict.update({"mappings.start": { "$gte": int(request.GET['range_start'])},
             "mappings.end": { "$lte": int(request.GET['range_end'])}})
+            filter_str += "starting from: " + request.GET['range_start'] + ", "
+            filter_str += "ending until: " + request.GET['range_end'] + ", "
+        try: # MAF value is a string, so this does not actually work!!
+            if request.GET['MAF'] is not None:
+                low = request.GET['MAF'].split("-")[0]
+                high = request.GET['MAF'].split("-")[1]
+                search_dict.update({"minor_allele_frequency": { "$gte": low , "$lte": high}})
+                filter_str += "MAF between: " + request.GET['MAF'] + ", "
+        except: pass
 
     try:
         if request.GET['limit'] is not None and request.GET['limit'] != "":
@@ -97,7 +114,7 @@ def results(request):
         limit = 20
 
     data_list = query_db(search_dict, limit)
-    content_dict = {'variants': data_list}
+    content_dict = {'filters': filter_str, 'variants': data_list}
     return render(request, "dbsnp_app/results.html", content_dict)
 
 # Available fields based on the first 200 records

--- a/dbSNP/dbsnp_app/views.py
+++ b/dbSNP/dbsnp_app/views.py
@@ -17,29 +17,42 @@ db_handle = client[database]
 collection_handle = db_handle[collection]
 
 
-def index(request):
-    return HttpResponse("Hello, world. You're at the index page.")
+def query_db(search_dict, limit):
+    data_list = []
+    variant_records = collection_handle.find(search_dict).limit(limit)
+    # Print on the terminal
+    for i, record in enumerate(variant_records):
+        # if i == 10: break
+        if 'clinical_significance' not in record.keys():
+            clinsig = None
+        else:
+            clinsig = ', '.join(record['clinical_significance'])
+
+        data_list.append({
+            'dbSNP_ID': record['name'],
+            'refGen': record['mappings'][0]['assembly_name'],
+            'chr': record['mappings'][0]['seq_region_name'],
+            'start': record['mappings'][0]['start'],
+            'end': record['mappings'][0]['end'],
+            'ref': record['ancestral_allele'],
+            'alt': record['minor_allele'],
+            'MAF': record['MAF'],
+            'var_class': record['var_class'],
+            'clin_sig': clinsig,
+            'consequence': record['most_severe_consequence'],
+            'evidence': ', '.join(record['evidence']),
+            'synonyms': record['synonyms']
+        })
+    return data_list
 
 
 def home(request):
-    data_list = []
-    variant_records = collection_handle.find().limit(22)
-    # Print on the terminal
-    for i, r in enumerate(variant_records):
-        # if i == 10: break
-        data_list.append({
-            'dbSNP_ID': r['name'],
-            'refGen': r['mappings'][0]['assembly_name'],
-            'chr': r['mappings'][0]['seq_region_name'],
-            'start': r['mappings'][0]['start'],
-            'end': r['mappings'][0]['end'],
-            'ref': r['ancestral_allele'],
-            'alt': r['minor_allele'],
-            'MAF': r['MAF'],
-            'var_class': r['var_class']
-        })
+    search_dict = {}
+    limit = 20
+
+    data_list = query_db(search_dict, limit)
     content_dict = {'variants': data_list}
-    return render(request, "dbsnp_app/home.html", content_dict)	
+    return render(request, "dbsnp_app/home.html", content_dict)
 
 # Available fields based on the first 200 records
 # {'_id': <class 'bson.objectid.ObjectId'>,


### PR DESCRIPTION
Merge dropdown filtering options from Chris with filtering on user input by Emily and Erin.
Now available:
- filter by exact match of any of the following: chromosome, start, end coordinates, variant type, consequence, clinical significance.
- filter by a range of positions (between start and end on a given chromosome)
- query criteria used is displayed on the results page
- can limit number of variants displayed on the results page

NOT available:
MAF is a string value, cannot do range comparison without conversion first.